### PR TITLE
Implement skeleton loading cards

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import dynamic from "next/dynamic";
 import { useStatuses } from "@/hooks/useStatuses";
 import { motion, AnimatePresence } from "framer-motion";
+import SkeletonCard from "@/components/ui/skeleton-card";
 
 const ThemeToggle = dynamic(
   () => import("@/components/ui/theme-toggle").then((mod) => mod.ThemeToggle),
@@ -61,26 +62,32 @@ export default function Home() {
         </div>
 
         <div className="w-full max-w-xl space-y-3">
-          {loading && <p>Загрузка статусов...</p>}
           {error && <p className="text-red-500">Ошибка: {error}</p>}
-          <AnimatePresence>
-            {filteredStatuses.map((status) => (
-              <motion.div
-                key={status.code}
-                {...cardMotion}
-                whileHover={{ scale: 1.03, boxShadow: "0 4px 24px rgba(0,0,0,0.10)" }}
-                className="bg-card border border-border p-4 rounded-xl shadow cursor-pointer transition-colors"
-              >
-                <div className="text-lg font-bold">{status.code}</div>
-                <div className="text-muted-foreground">{status.description}</div>
-                {status.action && (
-                  <div className="text-sm mt-1 text-muted-foreground">
-                    Действия: {status.action}
-                  </div>
-                )}
-              </motion.div>
-            ))}
-          </AnimatePresence>
+          {loading ? (
+            Array.from({ length: 6 }).map((_, i) => <SkeletonCard key={i} />)
+          ) : (
+            <AnimatePresence>
+              {filteredStatuses.map((status) => (
+                <motion.div
+                  key={status.code}
+                  {...cardMotion}
+                  whileHover={{
+                    scale: 1.03,
+                    boxShadow: "0 4px 24px rgba(0,0,0,0.10)",
+                  }}
+                  className="bg-card border border-border p-4 rounded-xl shadow cursor-pointer transition-colors"
+                >
+                  <div className="text-lg font-bold">{status.code}</div>
+                  <div className="text-muted-foreground">{status.description}</div>
+                  {status.action && (
+                    <div className="text-sm mt-1 text-muted-foreground">
+                      Действия: {status.action}
+                    </div>
+                  )}
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          )}
         </div>
       </div>
     </main>

--- a/src/components/ui/skeleton-card.tsx
+++ b/src/components/ui/skeleton-card.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { motion } from "framer-motion";
+
+export const SkeletonCard: React.FC = () => (
+  <motion.div
+    initial={{ opacity: 0 }}
+    animate={{ opacity: 1 }}
+    exit={{ opacity: 0 }}
+    transition={{ duration: 0.2 }}
+    className="bg-muted rounded-lg animate-pulse h-[140px] w-full max-w-[400px]"
+  />
+);
+
+export default SkeletonCard;


### PR DESCRIPTION
## Summary
- add `SkeletonCard` component
- render skeletons while statuses load

## Testing
- `npm run lint` *(fails: Invalid Options)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686fb9b141cc832ba8ce0e8dd04fabcb