### PR TITLE
Update search bar motion and glass styles

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,17 +56,18 @@ export default function Home() {
       </header>
 
       <motion.div
-        className="absolute left-1/2 -translate-x-1/2 flex flex-col items-center w-full max-w-xl px-4"
-        initial={false}
-        animate={{ top: moveUp ? "10vh" : "50vh" }}
-        transition={{ type: "spring", stiffness: 100 }}
-        style={{ translateY: "-50%" }}
+        className="absolute inset-0 flex items-center justify-center h-screen"
+        initial={{ y: 0 }}
+        animate={{ y: moveUp ? "-15vh" : "0vh" }}
+        transition={{ duration: 0.3, ease: "easeInOut" }}
       >
-        <h1 className="text-center text-2xl mb-4">{PAGE_TITLE}</h1>
-        <SearchBar query={query} setQuery={setQuery} />
+        <div className="w-full max-w-xl flex flex-col items-center px-4">
+          <h1 className="text-center text-2xl mb-4">{PAGE_TITLE}</h1>
+          <SearchBar query={query} setQuery={setQuery} />
+        </div>
       </motion.div>
 
-      <div className="pt-[calc(10vh+4rem)] px-4 w-full flex justify-center">
+      <div className="pt-[calc(15vh+4rem)] px-4 w-full flex justify-center">
         <div className="w-full max-w-xl space-y-3">
           {error && <p className="text-red-500">Ошибка: {error}</p>}
           {loading ? (
@@ -81,7 +82,7 @@ export default function Home() {
                     scale: 1.03,
                     boxShadow: "0 4px 24px rgba(0,0,0,0.10)",
                   }}
-                  className="backdrop-blur-md bg-white/30 dark:bg-neutral-800/30 border border-white/20 dark:border-neutral-700/20 rounded-xl p-4 shadow cursor-pointer transition-colors duration-300"
+                  className="bg-white/10 dark:bg-white/5 backdrop-blur-md border border-white/10 dark:border-white/10 shadow-inner rounded-xl p-4 cursor-pointer transition-colors duration-300"
                 >
                   <div className="text-lg font-bold">{status.code}</div>
                   <div className="text-muted-foreground">{status.description}</div>

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -34,7 +34,7 @@ export const Card: React.FC<CardProps> = ({ card, isActive, onClick }) => {
       {...listeners}
       onClick={onClick}
       className={cn(
-        "absolute w-[300px] h-[300px] bg-background rounded-2xl overflow-hidden shadow-lg cursor-pointer transform transition-transform duration-200 ease-out",
+        "absolute w-[300px] h-[300px] bg-white/10 dark:bg-white/5 backdrop-blur-md border border-white/10 dark:border-white/10 shadow-inner rounded-xl overflow-hidden cursor-pointer transform transition-transform duration-200 ease-out",
         isActive && "scale-105 ring-2 ring-primary"
       )}
       initial={{ opacity: 0, scale: 0.8 }}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -10,7 +10,7 @@ interface CardProps {
 export const Card: React.FC<CardProps> = ({ children, x, y }) => {
   return (
     <motion.div
-      className="absolute w-64 p-4 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg shadow-md"
+      className="absolute w-64 p-4 bg-white/10 dark:bg-white/5 backdrop-blur-md border border-white/10 dark:border-white/10 shadow-inner rounded-xl"
       style={{ left: x, top: y }}
       layout
     >

--- a/src/components/ui/search-bar.tsx
+++ b/src/components/ui/search-bar.tsx
@@ -44,7 +44,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({ query, setQuery, onPositio
       placeholder="Поиск статуса..."
       value={inputValue}
       onChange={(e) => setInputValue(e.target.value)}
-      className="px-4 py-3 text-lg backdrop-blur-md bg-white/30 dark:bg-neutral-800/30 border border-white/20 dark:border-neutral-700/20 rounded-xl text-foreground shadow focus:outline-none transition-transform transition-colors duration-200 hover:scale-105 focus:scale-105 focus:ring-1 focus:ring-accent"
+      className="px-4 py-3 text-lg bg-white/10 dark:bg-white/5 backdrop-blur-md border border-white/10 dark:border-white/10 shadow-inner rounded-xl text-foreground focus:outline-none transition-transform transition-colors duration-200 hover:scale-105 focus:scale-105 focus:ring-1 focus:ring-accent"
     />
   );
 };


### PR DESCRIPTION
## Summary
- animate search bar upward when results appear
- apply glassmorphism styles on search bar and cards
- center search bar with flexbox

## Testing
- `pnpm install`
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_686fe6f47f08832b90388cb6adc82310