### PR TITLE
Update UI with glass style and better search

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,9 +17,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className="transition-colors duration-500 ease-in-out"
+    >
       <body
-        className={`${inter.className} transition-colors duration-300 bg-white/10 dark:bg-neutral-900/10 backdrop-blur-lg`}
+        className={`${inter.className} transition-colors duration-500 ease-in-out`}
       >
         <ThemeProvider
           attribute="class"
@@ -27,7 +31,9 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          {children}
+          <div className="min-h-screen w-full bg-white/5 dark:bg-neutral-900/10 backdrop-blur-2xl transition-colors duration-500">
+            {children}
+          </div>
         </ThemeProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,8 +40,10 @@ export default function Home() {
       })
     : [];
 
+  const hasResults = filteredStatuses.length > 0;
+
   return (
-    <main className="relative flex flex-col items-center justify-center min-h-screen overflow-x-hidden bg-white/5 dark:bg-neutral-900/10 backdrop-blur-lg text-foreground pb-20 transition-colors duration-300">
+    <main className="relative flex flex-col items-center justify-center min-h-screen overflow-x-hidden text-foreground pb-20">
       {/* Header */}
       <header className="absolute top-4 left-0 right-0 flex justify-between items-center px-4 z-50">
         <div className="ml-4" />
@@ -50,8 +52,10 @@ export default function Home() {
         </div>
       </header>
 
-      <h1 className="text-center text-2xl">{PAGE_TITLE}</h1>
-      <SearchBar query={query} setQuery={setQuery} />
+      <h1 className="absolute top-6 left-6 text-xl font-semibold text-white/70 hover:text-white transition-colors">
+        WMS Stats
+      </h1>
+      <SearchBar query={query} setQuery={setQuery} hasResults={hasResults} />
       {loading && (
         <div className="-mt-2 flex justify-center">
           <LoadingText />
@@ -75,7 +79,7 @@ export default function Home() {
                   scale: 1.03,
                   boxShadow: "0 4px 24px rgba(0,0,0,0.10)",
                 }}
-                className="bg-white/10 dark:bg-neutral-800/10 backdrop-blur-md border border-white/10 rounded-xl shadow p-4"
+                className="rounded-xl border border-white/10 bg-white/5 dark:bg-white/10 backdrop-blur-md p-4 shadow-lg transition-all"
               >
                 <div className="text-lg font-bold">{status.code}</div>
                 <div className="text-muted-foreground">{status.description}</div>
@@ -87,6 +91,11 @@ export default function Home() {
               </motion.div>
             ))}
           </AnimatePresence>
+        )}
+        {!loading && query && !hasResults && (
+          <motion.div className="text-muted-foreground italic mt-4">
+            Ничего не найдено
+          </motion.div>
         )}
       </motion.div>
     </main>

--- a/src/components/ui/search-bar.tsx
+++ b/src/components/ui/search-bar.tsx
@@ -2,13 +2,15 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
+import { Search, X } from "lucide-react";
 
 interface SearchBarProps {
   query: string;
   setQuery: (q: string) => void;
+  hasResults: boolean;
 }
 
-export const SearchBar: React.FC<SearchBarProps> = ({ query, setQuery }) => {
+export const SearchBar: React.FC<SearchBarProps> = ({ query, setQuery, hasResults }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = useState(query);
   const [debouncedValue, setDebouncedValue] = useState(query);
@@ -29,19 +31,29 @@ export const SearchBar: React.FC<SearchBarProps> = ({ query, setQuery }) => {
 
   return (
     <motion.div
-      animate={{ y: inputValue ? -80 : 0 }}
-      transition={{ type: "spring", stiffness: 120, damping: 20 }}
-      className="relative z-10 w-full max-w-[480px]"
+      animate={{ y: hasResults ? -80 : 0 }}
+      transition={{ duration: 0.4, ease: "easeInOut" }}
+      className="fixed left-1/2 top-20 z-40 w-[320px] -translate-x-1/2"
     >
-      <div className="bg-white/10 dark:bg-neutral-900/10 backdrop-blur-lg border border-white/10 rounded-xl shadow-md px-4 py-2 transition-all focus-within:ring-2 focus-within:ring-accent scale-100 focus-within:scale-105">
+      <div className="relative rounded-xl bg-white/10 dark:bg-white/5 border border-white/10 backdrop-blur-md shadow-md px-4 py-2 text-base w-full">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <input
           ref={inputRef}
           type="text"
           placeholder="Поиск статуса..."
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
-          className="w-full bg-transparent outline-none"
+          className="w-full bg-transparent pl-8 pr-8 outline-none"
         />
+        {inputValue && (
+          <button
+            type="button"
+            onClick={() => setInputValue("")}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
       </div>
     </motion.div>
   );


### PR DESCRIPTION
## Summary
- polish search bar with glass effect, icons and sticky animation
- refresh layout background and theme transitions
- adjust heading placement and card styles
- show message when no statuses match

## Testing
- `npx biome check src/app/page.tsx src/components/ui/search-bar.tsx src/app/layout.tsx`
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_68740ec11144832b8c21581a68d7191f