### PR TITLE
Update search UI and card styles

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,10 +23,10 @@ export default function Home() {
   const { statuses, loading, error } = useStatuses();
 
   const cardMotion = {
-    initial: { opacity: 0, y: 8 },
+    initial: { opacity: 0, y: 20 },
     animate: { opacity: 1, y: 0 },
-    exit: { opacity: 0, y: -8 },
-    transition: { duration: 0.25, ease: "easeInOut" },
+    exit: { opacity: 0, y: 20 },
+    transition: { duration: 0.3, ease: "easeInOut" },
   };
 
   const filteredStatuses = query.length
@@ -52,10 +52,8 @@ export default function Home() {
         </div>
       </header>
 
-      <h1 className="absolute top-6 left-6 text-xl font-semibold text-white/70 hover:text-white transition-colors">
-        WMS Stats
-      </h1>
-      <SearchBar query={query} setQuery={setQuery} hasResults={hasResults} />
+      <div className="fixed top-4 left-4 text-white font-semibold text-lg">WMS Stats</div>
+      <SearchBar query={query} setQuery={setQuery} />
       {loading && (
         <div className="-mt-2 flex justify-center">
           <LoadingText />
@@ -63,7 +61,7 @@ export default function Home() {
       )}
 
       <motion.div
-        className="max-h-[60vh] overflow-y-auto mt-6 w-full max-w-[800px] space-y-4 px-4"
+        className="max-h-[70vh] overflow-y-auto mt-6 w-full max-w-[800px] space-y-4 px-4"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.3 }}
@@ -75,11 +73,8 @@ export default function Home() {
               <motion.div
                 key={status.code}
                 {...cardMotion}
-                whileHover={{
-                  scale: 1.03,
-                  boxShadow: "0 4px 24px rgba(0,0,0,0.10)",
-                }}
-                className="rounded-xl border border-white/10 bg-white/5 dark:bg-white/10 backdrop-blur-md p-4 shadow-lg transition-all"
+                whileHover={{ y: -4, boxShadow: "0 4px 24px rgba(0,0,0,0.1)" }}
+                className="rounded-2xl bg-white/10 backdrop-blur-md text-white shadow-[0_4px_30px_rgba(0,0,0,0.1)] p-4 space-y-1 hover:-translate-y-1 hover:shadow-lg transition-all duration-300"
               >
                 <div className="text-lg font-bold">{status.code}</div>
                 <div className="text-muted-foreground">{status.description}</div>

--- a/src/components/ui/search-bar.tsx
+++ b/src/components/ui/search-bar.tsx
@@ -1,16 +1,15 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import { motion } from "framer-motion";
-import { Search, X } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+import { X } from "lucide-react";
 
 interface SearchBarProps {
   query: string;
   setQuery: (q: string) => void;
-  hasResults: boolean;
 }
 
-export const SearchBar: React.FC<SearchBarProps> = ({ query, setQuery, hasResults }) => {
+export const SearchBar: React.FC<SearchBarProps> = ({ query, setQuery }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = useState(query);
   const [debouncedValue, setDebouncedValue] = useState(query);
@@ -30,31 +29,39 @@ export const SearchBar: React.FC<SearchBarProps> = ({ query, setQuery, hasResult
   }, [debouncedValue, setQuery]);
 
   return (
-    <motion.div
-      animate={{ y: hasResults ? -80 : 0 }}
-      transition={{ duration: 0.4, ease: "easeInOut" }}
-      className="fixed left-1/2 top-20 z-40 w-[320px] -translate-x-1/2"
-    >
-      <div className="relative rounded-xl bg-white/10 dark:bg-white/5 border border-white/10 backdrop-blur-md shadow-md px-4 py-2 text-base w-full">
-        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-        <input
-          ref={inputRef}
-          type="text"
-          placeholder="Поиск статуса..."
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          className="w-full bg-transparent pl-8 pr-8 outline-none"
-        />
-        {inputValue && (
-          <button
-            type="button"
-            onClick={() => setInputValue("")}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        )}
-      </div>
-    </motion.div>
+    <div className="fixed inset-0 z-40 flex items-center justify-center pointer-events-none">
+      <motion.div
+        animate={{ y: inputValue.length > 0 ? -150 : 0 }}
+        transition={{ duration: 0.4, ease: 'easeInOut' }}
+        className="pointer-events-auto w-full px-4"
+      >
+        <div className="relative mx-auto w-full max-w-md">
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder="Поиск статуса..."
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            className="w-full max-w-md px-4 py-2 rounded-xl bg-black/30 backdrop-blur-md text-white placeholder:text-gray-400 outline-none transition-all duration-300 focus:ring-2 ring-violet-400 shadow-[0_4px_30px_rgba(0,0,0,0.1)]"
+          />
+          <AnimatePresence>
+            {inputValue.length > 0 && (
+              <motion.button
+                key="clear"
+                type="button"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2 }}
+                onClick={() => setInputValue('')}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-white hover:text-gray-200"
+              >
+                <X className="h-4 w-4" />
+              </motion.button>
+            )}
+          </AnimatePresence>
+        </div>
+      </motion.div>
+    </div>
   );
 };


### PR DESCRIPTION
## Summary
- center search bar and animate upward on input
- add clear button with framer-motion
- glassmorphism cards with entrance animation
- adjust card container height and title placement

## Testing
- `npm install`
- `npm run lint` *(fails: Invalid Options)*
- `npx -y biome check`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687413054be4832b8fb8f2f8c757bb8f