### PR TITLE
Apply glassmorphism to search UI

### DIFF
--- a/src/components/InputSearch.tsx
+++ b/src/components/InputSearch.tsx
@@ -24,7 +24,7 @@ const InputSearch: React.FC<Props> = ({ query, onChange, onClear }) => {
             placeholder="Поиск статуса..."
             value={query}
             onChange={(e) => onChange(e.target.value)}
-            className="w-full rounded-xl bg-card text-card-foreground placeholder:text-muted-foreground shadow-md px-4 py-3 outline-none"
+            className="w-full rounded-2xl border border-white/20 bg-black/10 dark:bg-white/10 backdrop-blur-lg text-card-foreground placeholder:text-muted-foreground shadow-[0_4px_12px_rgba(0,0,0,0.1)] dark:shadow-[0_4px_12px_rgba(0,0,0,0.5)] px-4 py-3 outline-none transition-all duration-200 ease-in-out focus:shadow-[0_0_0_3px_rgba(255,255,255,0.2)]"
           />
           <AnimatePresence>
             {query && (

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -15,8 +15,8 @@ const SearchResults: React.FC<Props> = ({ visible, children }) => (
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: 10 }}
-        transition={{ duration: 0.3 }}
-        className="mt-4 max-h-[60vh] w-full max-w-md overflow-y-auto space-y-3 px-4"
+        transition={{ duration: 0.2 }}
+        className="mt-4 max-h-[60vh] w-full mx-auto max-w-[90%] md:max-w-[60%] overflow-y-auto space-y-3 px-4"
       >
         {children}
       </motion.div>

--- a/src/components/StatusCard.tsx
+++ b/src/components/StatusCard.tsx
@@ -26,11 +26,11 @@ function highlight(text: string, query: string) {
 const StatusCard: React.FC<Props> = ({ status, query }) => {
   return (
     <motion.div
-      initial={{ opacity: 0, scale: 0.95 }}
-      animate={{ opacity: 1, scale: 1 }}
-      exit={{ opacity: 0, scale: 0.95 }}
-      transition={{ duration: 0.3 }}
-      className="rounded-xl bg-card text-card-foreground shadow-md p-4 space-y-1"
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 10 }}
+      transition={{ duration: 0.2 }}
+      className="rounded-2xl border border-white/20 bg-black/10 dark:bg-white/10 backdrop-blur-lg text-card-foreground shadow-[0_4px_12px_rgba(0,0,0,0.1)] dark:shadow-[0_4px_12px_rgba(0,0,0,0.5)] p-4 space-y-1 transition-all duration-200 ease-in-out"
     >
       <div className="font-bold text-lg">{highlight(status.code, query)}</div>
       <div>{highlight(status.description, query)}</div>


### PR DESCRIPTION
## Summary
- add soft glass blur styles for search input
- make result cards translucent with fade animations
- resize results container for mobile/desktop

## Testing
- `npm install`
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_6874d78543e0832ba493554d305b8b3b