### PR TITLE
Add client-side SKU/price extractor tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev -H 0.0.0.0",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -37,7 +38,8 @@
     "eslint-config-next": "^15.3.0",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.3.6",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^3.2.4"
   },
   "packageManager": "pnpm@10.8.0+sha512.0e82714d1b5b43c74610193cb20734897c1d00de89d0e18420aebc5977fa13d780a9cb05734624e81ebd81cc876cd464794850641c48b9544326b5622ca29971"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@20.17.30)(jiti@1.21.7)(yaml@2.7.1)
 
 packages:
 
@@ -139,6 +142,162 @@ packages:
 
   '@emotion/memoize@0.7.4':
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+
+  '@esbuild/aix-ppc64@0.25.10':
+    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.10':
+    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.10':
+    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.10':
+    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.10':
+    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.10':
+    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.10':
+    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.10':
+    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.10':
+    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.10':
+    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.10':
+    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.10':
+    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.10':
+    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.10':
+    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.10':
+    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.10':
+    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.10':
+    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.10':
+    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.10':
+    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.10':
+    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.10':
+    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.10':
+    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.6.0':
     resolution: {integrity: sha512-WhCn7Z7TauhBtmzhvKpoQs0Wwb/kBcy4CwpuI0/eEIr2Lx2auxmulAzLr91wVZJaz47iUZdkXOK7WlAfxGKCnA==}
@@ -314,6 +473,9 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
@@ -652,6 +814,116 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rollup/rollup-android-arm-eabi@4.52.3':
+    resolution: {integrity: sha512-h6cqHGZ6VdnwliFG1NXvMPTy/9PS3h8oLh7ImwR+kl+oYnQizgjxsONmmPSb2C66RksfkfIxEVtDSEcJiO0tqw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.52.3':
+    resolution: {integrity: sha512-wd+u7SLT/u6knklV/ifG7gr5Qy4GUbH2hMWcDauPFJzmCZUAJ8L2bTkVXC2niOIxp8lk3iH/QX8kSrUxVZrOVw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.52.3':
+    resolution: {integrity: sha512-lj9ViATR1SsqycwFkJCtYfQTheBdvlWJqzqxwc9f2qrcVrQaF/gCuBRTiTolkRWS6KvNxSk4KHZWG7tDktLgjg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.52.3':
+    resolution: {integrity: sha512-+Dyo7O1KUmIsbzx1l+4V4tvEVnVQqMOIYtrxK7ncLSknl1xnMHLgn7gddJVrYPNZfEB8CIi3hK8gq8bDhb3h5A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.52.3':
+    resolution: {integrity: sha512-u9Xg2FavYbD30g3DSfNhxgNrxhi6xVG4Y6i9Ur1C7xUuGDW3banRbXj+qgnIrwRN4KeJ396jchwy9bCIzbyBEQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.52.3':
+    resolution: {integrity: sha512-5M8kyi/OX96wtD5qJR89a/3x5x8x5inXBZO04JWhkQb2JWavOWfjgkdvUqibGJeNNaz1/Z1PPza5/tAPXICI6A==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.3':
+    resolution: {integrity: sha512-IoerZJ4l1wRMopEHRKOO16e04iXRDyZFZnNZKrWeNquh5d6bucjezgd+OxG03mOMTnS1x7hilzb3uURPkJ0OfA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.3':
+    resolution: {integrity: sha512-ZYdtqgHTDfvrJHSh3W22TvjWxwOgc3ThK/XjgcNGP2DIwFIPeAPNsQxrJO5XqleSlgDux2VAoWQ5iJrtaC1TbA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.3':
+    resolution: {integrity: sha512-NcViG7A0YtuFDA6xWSgmFb6iPFzHlf5vcqb2p0lGEbT+gjrEEz8nC/EeDHvx6mnGXnGCC1SeVV+8u+smj0CeGQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.52.3':
+    resolution: {integrity: sha512-d3pY7LWno6SYNXRm6Ebsq0DJGoiLXTb83AIPCXl9fmtIQs/rXoS8SJxxUNtFbJ5MiOvs+7y34np77+9l4nfFMw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.3':
+    resolution: {integrity: sha512-3y5GA0JkBuirLqmjwAKwB0keDlI6JfGYduMlJD/Rl7fvb4Ni8iKdQs1eiunMZJhwDWdCvrcqXRY++VEBbvk6Eg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.3':
+    resolution: {integrity: sha512-AUUH65a0p3Q0Yfm5oD2KVgzTKgwPyp9DSXc3UA7DtxhEb/WSPfbG4wqXeSN62OG5gSo18em4xv6dbfcUGXcagw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.3':
+    resolution: {integrity: sha512-1makPhFFVBqZE+XFg3Dkq+IkQ7JvmUrwwqaYBL2CE+ZpxPaqkGaiWFEWVGyvTwZace6WLJHwjVh/+CXbKDGPmg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.3':
+    resolution: {integrity: sha512-OOFJa28dxfl8kLOPMUOQBCO6z3X2SAfzIE276fwT52uXDWUS178KWq0pL7d6p1kz7pkzA0yQwtqL0dEPoVcRWg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.3':
+    resolution: {integrity: sha512-jMdsML2VI5l+V7cKfZx3ak+SLlJ8fKvLJ0Eoa4b9/vCUrzXKgoKxvHqvJ/mkWhFiyp88nCkM5S2v6nIwRtPcgg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.52.3':
+    resolution: {integrity: sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.52.3':
+    resolution: {integrity: sha512-BCFkJjgk+WFzP+tcSMXq77ymAPIxsX9lFJWs+2JzuZTLtksJ2o5hvgTdIcZ5+oKzUDMwI0PfWzRBYAydAHF2Mw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.52.3':
+    resolution: {integrity: sha512-KTD/EqjZF3yvRaWUJdD1cW+IQBk4fbQaHYJUmP8N4XoKFZilVL8cobFSTDnjTtxWJQ3JYaMgF4nObY/+nYkumA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.3':
+    resolution: {integrity: sha512-+zteHZdoUYLkyYKObGHieibUFLbttX2r+58l27XZauq0tcWYYuKUwY2wjeCN9oK1Um2YgH2ibd6cnX/wFD7DuA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.3':
+    resolution: {integrity: sha512-of1iHkTQSo3kr6dTIRX6t81uj/c/b15HXVsPcEElN5sS859qHrOepM5p9G41Hah+CTqSh2r8Bm56dL2z9UQQ7g==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.52.3':
+    resolution: {integrity: sha512-s0hybmlHb56mWVZQj8ra9048/WZTPLILKxcvcq+8awSZmyiSUZjjem1AhU3Tf4ZKpYhK4mg36HtHDOe8QJS5PQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.52.3':
+    resolution: {integrity: sha512-zGIbEVVXVtauFgl3MRwGWEN36P5ZGenHRMgNw88X5wEhEBpq0XrMEZwOn07+ICrwM17XO5xfMZqh0OldCH5VTA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -666,6 +938,15 @@ packages:
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -814,6 +1095,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -900,6 +1210,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -961,6 +1275,10 @@ packages:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -984,9 +1302,17 @@ packages:
   caniuse-lite@1.0.30001713:
     resolution: {integrity: sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1067,6 +1393,19 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1138,6 +1477,9 @@ packages:
     resolution: {integrity: sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1153,6 +1495,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.25.10:
+    resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1270,9 +1617,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1299,6 +1653,15 @@ packages:
 
   fdir@6.4.3:
     resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -1634,6 +1997,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -1696,6 +2062,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -1703,6 +2072,9 @@ packages:
     resolution: {integrity: sha512-59MiDzDzFI/efHhb4n0vGdXelMNwou7JlAFvVS4boA1G/7aYU7garPciYo73CODzkhrhz0JOgdtSTPSe5dMrlQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
+
+  magic-string@0.30.19:
+    resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1873,6 +2245,13 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1882,6 +2261,10 @@ packages:
 
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
   pify@2.3.0:
@@ -1939,6 +2322,10 @@ packages:
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2041,6 +2428,11 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  rollup@4.52.3:
+    resolution: {integrity: sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2111,6 +2503,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2124,6 +2519,12 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -2176,6 +2577,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -2225,9 +2629,31 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.12:
     resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2334,6 +2760,79 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.1.7:
+    resolution: {integrity: sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -2359,6 +2858,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2458,6 +2962,84 @@ snapshots:
     optional: true
 
   '@emotion/memoize@0.7.4':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm@0.25.10':
+    optional: true
+
+  '@esbuild/android-x64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.10':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.10':
     optional: true
 
   '@eslint-community/eslint-utils@4.6.0(eslint@8.57.1)':
@@ -2610,6 +3192,8 @@ snapshots:
   '@jridgewell/set-array@1.2.1': {}
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
@@ -2902,6 +3486,72 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rollup/rollup-android-arm-eabi@4.52.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.52.3':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.52.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.52.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.52.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.52.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.52.3':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.52.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.52.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.52.3':
+    optional: true
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.11.0': {}
@@ -2916,6 +3566,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/json5@0.0.29': {}
 
@@ -3063,6 +3721,48 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.5.0':
     optional: true
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.1.7(@types/node@20.17.30)(jiti@1.21.7)(yaml@2.7.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      vite: 7.1.7(@types/node@20.17.30)(jiti@1.21.7)(yaml@2.7.1)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.0.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.19
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   acorn-jsx@5.3.2(acorn@8.14.1):
     dependencies:
       acorn: 8.14.1
@@ -3170,6 +3870,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -3226,6 +3928,8 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -3249,10 +3953,20 @@ snapshots:
 
   caniuse-lite@1.0.30001713: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@2.1.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -3333,6 +4047,12 @@ snapshots:
   debug@4.4.0:
     dependencies:
       ms: 2.1.3
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
 
@@ -3462,6 +4182,8 @@ snapshots:
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -3483,6 +4205,35 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  esbuild@0.25.10:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.10
+      '@esbuild/android-arm': 0.25.10
+      '@esbuild/android-arm64': 0.25.10
+      '@esbuild/android-x64': 0.25.10
+      '@esbuild/darwin-arm64': 0.25.10
+      '@esbuild/darwin-x64': 0.25.10
+      '@esbuild/freebsd-arm64': 0.25.10
+      '@esbuild/freebsd-x64': 0.25.10
+      '@esbuild/linux-arm': 0.25.10
+      '@esbuild/linux-arm64': 0.25.10
+      '@esbuild/linux-ia32': 0.25.10
+      '@esbuild/linux-loong64': 0.25.10
+      '@esbuild/linux-mips64el': 0.25.10
+      '@esbuild/linux-ppc64': 0.25.10
+      '@esbuild/linux-riscv64': 0.25.10
+      '@esbuild/linux-s390x': 0.25.10
+      '@esbuild/linux-x64': 0.25.10
+      '@esbuild/netbsd-arm64': 0.25.10
+      '@esbuild/netbsd-x64': 0.25.10
+      '@esbuild/openbsd-arm64': 0.25.10
+      '@esbuild/openbsd-x64': 0.25.10
+      '@esbuild/openharmony-arm64': 0.25.10
+      '@esbuild/sunos-x64': 0.25.10
+      '@esbuild/win32-arm64': 0.25.10
+      '@esbuild/win32-ia32': 0.25.10
+      '@esbuild/win32-x64': 0.25.10
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -3495,8 +4246,8 @@ snapshots:
       '@typescript-eslint/parser': 8.29.1(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -3515,7 +4266,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -3526,22 +4277,22 @@ snapshots:
       tinyglobby: 0.2.12
       unrs-resolver: 1.5.0
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.29.1(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -3552,7 +4303,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -3683,7 +4434,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.2.2: {}
 
   extend@3.0.2: {}
 
@@ -3716,6 +4473,10 @@ snapshots:
   fdir@6.4.3(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -4102,6 +4863,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -4167,11 +4930,17 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lru-cache@10.4.3: {}
 
   lucide-react@0.299.0(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  magic-string@0.30.19:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
 
@@ -4337,11 +5106,17 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  picomatch@4.0.3: {}
 
   pify@2.3.0: {}
 
@@ -4387,6 +5162,12 @@ snapshots:
       source-map-js: 1.2.1
 
   postcss@8.5.3:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -4496,6 +5277,34 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rollup@4.52.3:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.3
+      '@rollup/rollup-android-arm64': 4.52.3
+      '@rollup/rollup-darwin-arm64': 4.52.3
+      '@rollup/rollup-darwin-x64': 4.52.3
+      '@rollup/rollup-freebsd-arm64': 4.52.3
+      '@rollup/rollup-freebsd-x64': 4.52.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.3
+      '@rollup/rollup-linux-arm64-gnu': 4.52.3
+      '@rollup/rollup-linux-arm64-musl': 4.52.3
+      '@rollup/rollup-linux-loong64-gnu': 4.52.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.3
+      '@rollup/rollup-linux-riscv64-musl': 4.52.3
+      '@rollup/rollup-linux-s390x-gnu': 4.52.3
+      '@rollup/rollup-linux-x64-gnu': 4.52.3
+      '@rollup/rollup-linux-x64-musl': 4.52.3
+      '@rollup/rollup-openharmony-arm64': 4.52.3
+      '@rollup/rollup-win32-arm64-msvc': 4.52.3
+      '@rollup/rollup-win32-ia32-msvc': 4.52.3
+      '@rollup/rollup-win32-x64-gnu': 4.52.3
+      '@rollup/rollup-win32-x64-msvc': 4.52.3
+      fsevents: 2.3.3
 
   run-parallel@1.2.0:
     dependencies:
@@ -4614,6 +5423,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-swizzle@0.2.2:
@@ -4624,6 +5435,10 @@ snapshots:
   source-map-js@1.2.1: {}
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.9.0: {}
 
   streamsearch@1.1.0: {}
 
@@ -4701,6 +5516,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   styled-jsx@5.1.6(react@18.3.1):
     dependencies:
       client-only: 0.0.1
@@ -4765,10 +5584,25 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.12:
     dependencies:
       fdir: 6.4.3(picomatch@4.0.2)
       picomatch: 4.0.2
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4895,6 +5729,82 @@ snapshots:
 
   uuid@9.0.1: {}
 
+  vite-node@3.2.4(@types/node@20.17.30)(jiti@1.21.7)(yaml@2.7.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.7(@types/node@20.17.30)(jiti@1.21.7)(yaml@2.7.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.1.7(@types/node@20.17.30)(jiti@1.21.7)(yaml@2.7.1):
+    dependencies:
+      esbuild: 0.25.10
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.52.3
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.17.30
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      yaml: 2.7.1
+
+  vitest@3.2.4(@types/node@20.17.30)(jiti@1.21.7)(yaml@2.7.1):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.1.7(@types/node@20.17.30)(jiti@1.21.7)(yaml@2.7.1))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.19
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.7(@types/node@20.17.30)(jiti@1.21.7)(yaml@2.7.1)
+      vite-node: 3.2.4(@types/node@20.17.30)(jiti@1.21.7)(yaml@2.7.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.17.30
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   webidl-conversions@3.0.1: {}
 
   whatwg-url@5.0.0:
@@ -4946,6 +5856,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,13 @@
 "use client";
 
 import React from "react";
-import dynamic from "next/dynamic";
 import { motion } from "framer-motion";
 import LoadingText from "@/components/ui/loading-text";
 import { useSearch } from "@/hooks/useSearch";
 import InputSearch from "@/components/InputSearch";
 import SearchResults from "@/components/SearchResults";
 import StatusCard from "@/components/StatusCard";
-
-const ThemeToggle = dynamic(
-  () => import("@/components/ui/theme-toggle").then((mod) => mod.ThemeToggle),
-  { ssr: false }
-);
+import { AppHeader } from "@/components/AppHeader";
 
 const PAGE_TITLE = "Warehouse Statuses";
 
@@ -21,16 +16,8 @@ export default function Home() {
   const hasResults = results.length > 0;
 
   return (
-    <main className="relative flex flex-col items-center justify-center min-h-screen overflow-x-hidden text-foreground pb-20">
-      {/* Header */}
-      <header className="absolute top-4 left-0 right-0 flex justify-between items-center px-4 z-50">
-        <div className="ml-4" />
-        <div className="flex items-center gap-4">
-          <ThemeToggle />
-        </div>
-      </header>
-
-      <div className="fixed top-4 left-4 text-white font-semibold text-lg">WMS Stats</div>
+    <main className="relative flex min-h-screen flex-col items-center justify-center overflow-x-hidden pb-20 pt-28 text-foreground">
+      <AppHeader />
       <InputSearch query={query} onChange={setQuery} onClear={clear} />
       {loading && (
         <div className="-mt-2 flex justify-center">

--- a/src/app/tools/extractor/page.tsx
+++ b/src/app/tools/extractor/page.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AppHeader } from "@/components/AppHeader";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { PriceFormat, parsePrices, parseSkus } from "@/lib/extractor";
+
+const MODE_OPTIONS = [
+  { value: "sku" as const, label: "ШК" },
+  { value: "price" as const, label: "Стоимость" },
+];
+
+const PRICE_FORMAT_OPTIONS: { value: PriceFormat; label: string }[] = [
+  { value: "report", label: "Формат вывода: отчёт" },
+  { value: "excel", label: "Формат вывода: Excel/CSV" },
+];
+
+interface ToastState {
+  id: number;
+  message: string;
+}
+
+export default function ExtractorPage() {
+  const [mode, setMode] = useState<(typeof MODE_OPTIONS)[number]["value"]>("sku");
+  const [priceFormat, setPriceFormat] = useState<PriceFormat>("report");
+  const [unique, setUnique] = useState(true);
+  const [raw, setRaw] = useState("");
+  const [result, setResult] = useState<string[]>([]);
+  const [toast, setToast] = useState<ToastState | null>(null);
+  const [hasProcessed, setHasProcessed] = useState(false);
+  const [lastProcessedRaw, setLastProcessedRaw] = useState("");
+
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const resultRef = useRef<HTMLTextAreaElement | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  const resultCount = result.length;
+  const resultTitle = useMemo(
+    () =>
+      mode === "sku"
+        ? `Результат (ШК): ${resultCount}`
+        : `Результат (стоимость): ${resultCount}`,
+    [mode, resultCount]
+  );
+
+  const showToast = useCallback((message: string) => {
+    if (toastTimer.current) {
+      clearTimeout(toastTimer.current);
+    }
+
+    const nextToast = { id: Date.now(), message };
+    setToast(nextToast);
+    toastTimer.current = setTimeout(() => {
+      setToast((current) => (current?.id === nextToast.id ? null : current));
+    }, 2200);
+  }, []);
+
+  const processInput = useCallback(
+    (input: string, { notify }: { notify: boolean }) => {
+      const trimmed = input.trim();
+      if (!trimmed) {
+        setResult([]);
+        if (notify) {
+          showToast("Готово: 0 элементов");
+        }
+        return 0;
+      }
+
+      const parsed =
+        mode === "sku"
+          ? parseSkus(input, { unique })
+          : parsePrices(input, { unique, format: priceFormat });
+
+      setResult(parsed);
+
+      if (notify) {
+        showToast(`Готово: ${parsed.length} элементов`);
+      }
+
+      return parsed.length;
+    },
+    [mode, priceFormat, showToast, unique]
+  );
+
+  const handleProcess = useCallback(() => {
+    processInput(raw, { notify: true });
+    setLastProcessedRaw(raw);
+    setHasProcessed(true);
+  }, [processInput, raw]);
+
+  const handlePaste = useCallback(async () => {
+    try {
+      if (!navigator.clipboard || !navigator.clipboard.readText) {
+        showToast("Не удалось получить доступ к буферу обмена");
+        return;
+      }
+
+      const text = await navigator.clipboard.readText();
+      if (text !== undefined) {
+        setRaw(text);
+        requestAnimationFrame(() => {
+          inputRef.current?.focus();
+          inputRef.current?.setSelectionRange(text.length, text.length);
+        });
+        showToast("Данные вставлены");
+      }
+    } catch (error) {
+      console.error(error);
+      showToast("Не удалось получить данные из буфера обмена");
+    }
+  }, [showToast]);
+
+  const handleCopy = useCallback(async () => {
+    const content = result.join("\n");
+    if (!content) {
+      showToast("Нет данных для копирования");
+      return;
+    }
+
+    try {
+      if (!navigator.clipboard || !navigator.clipboard.writeText) {
+        showToast("Скопируйте данные вручную");
+        return;
+      }
+
+      await navigator.clipboard.writeText(content);
+      showToast("Скопировано");
+    } catch (error) {
+      console.error(error);
+      showToast("Не удалось скопировать данные");
+    }
+  }, [result, showToast]);
+
+  const handleDownload = useCallback(() => {
+    const content = result.join("\n");
+    if (!content) {
+      showToast("Нет данных для сохранения");
+      return;
+    }
+
+    const blob = new Blob([content], { type: "text/plain;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = mode === "sku" ? "skus.txt" : "prices.txt";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [mode, result, showToast]);
+
+  useEffect(() => {
+    if (!hasProcessed) return;
+    if (raw !== lastProcessedRaw) return;
+
+    processInput(lastProcessedRaw, { notify: false });
+  }, [hasProcessed, lastProcessedRaw, processInput, priceFormat, mode, unique, raw]);
+
+  useEffect(() => {
+    if (!lastProcessedRaw) return;
+    if (raw !== lastProcessedRaw) {
+      setHasProcessed(false);
+    }
+  }, [raw, lastProcessedRaw]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const key = event.key.toLowerCase();
+      const target = event.target as HTMLElement | null;
+      const isEditableTarget =
+        !!target &&
+        (target.isContentEditable ||
+          target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA");
+      const isInputFocused = target === inputRef.current;
+      const isResultFocused = target === resultRef.current;
+
+      if (event.ctrlKey && key === "enter") {
+        event.preventDefault();
+        handleProcess();
+        return;
+      }
+
+      if (event.ctrlKey && key === "v") {
+        if (!isEditableTarget || isInputFocused) {
+          event.preventDefault();
+          handlePaste();
+        }
+        return;
+      }
+
+      if (event.ctrlKey && key === "c") {
+        if (!isEditableTarget || isResultFocused) {
+          event.preventDefault();
+          handleCopy();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleCopy, handlePaste, handleProcess]);
+
+  useEffect(() => {
+    return () => {
+      if (toastTimer.current) {
+        clearTimeout(toastTimer.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div className="relative min-h-screen bg-background pb-16 pt-28 text-foreground">
+      <AppHeader />
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6">
+        <div className="flex flex-col gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold">Выделитель ШК/стоимости</h1>
+            <p className="text-sm text-muted-foreground">
+              Вставьте данные из отчёта, выберите режим и получите очищенный список.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="flex gap-2 rounded-lg bg-muted p-1 text-sm">
+              {MODE_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setMode(option.value)}
+                  className={cn(
+                    "rounded-md px-4 py-2 font-medium transition-colors",
+                    mode === option.value
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+            {mode === "price" && (
+              <div className="flex gap-2 rounded-lg bg-muted p-1 text-sm">
+                {PRICE_FORMAT_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => setPriceFormat(option.value)}
+                    className={cn(
+                      "rounded-md px-4 py-2 font-medium transition-colors",
+                      priceFormat === option.value
+                        ? "bg-background text-foreground shadow-sm"
+                        : "text-muted-foreground hover:text-foreground"
+                    )}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            )}
+            <label className="flex items-center gap-2 text-sm text-foreground">
+              <input
+                type="checkbox"
+                checked={unique}
+                onChange={(event) => setUnique(event.target.checked)}
+                className="h-4 w-4 rounded border border-border bg-background text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+              Уникальные (с сохранением порядка)
+            </label>
+          </div>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          <div className="flex flex-col gap-4 rounded-2xl border border-border bg-card/60 p-6 shadow-lg backdrop-blur">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <h2 className="text-lg font-semibold">Исходные данные</h2>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  onClick={handlePaste}
+                  className="h-9 bg-muted px-4 py-2 text-sm font-medium text-foreground hover:bg-muted/80"
+                >
+                  Вставить из буфера
+                </Button>
+                <Button type="button" onClick={handleProcess} className="h-9 px-4 py-2 text-sm font-semibold">
+                  Очистить →
+                </Button>
+              </div>
+            </div>
+            <textarea
+              ref={inputRef}
+              value={raw}
+              onChange={(event) => setRaw(event.target.value)}
+              placeholder="Вставьте данные отчёта или списка..."
+              className="h-80 w-full resize-none rounded-lg border border-border bg-background/60 px-4 py-3 font-mono text-sm text-foreground shadow-sm outline-none transition focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
+            />
+            <p className="text-xs text-muted-foreground">Подсказка: можно вставлять Ctrl+V</p>
+          </div>
+
+          <div className="flex flex-col gap-4 rounded-2xl border border-border bg-card/60 p-6 shadow-lg backdrop-blur">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <h2 className="text-lg font-semibold">{resultTitle}</h2>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  onClick={handleCopy}
+                  className="h-9 bg-muted px-4 py-2 text-sm font-medium text-foreground hover:bg-muted/80"
+                >
+                  Копировать результат
+                </Button>
+                <Button
+                  type="button"
+                  onClick={handleDownload}
+                  className="h-9 px-4 py-2 text-sm font-semibold"
+                >
+                  Скачать .txt
+                </Button>
+              </div>
+            </div>
+            <textarea
+              ref={resultRef}
+              value={result.join("\n")}
+              readOnly
+              spellCheck={false}
+              className="h-80 w-full resize-none rounded-lg border border-border bg-background/40 px-4 py-3 font-mono text-sm text-foreground opacity-90 shadow-sm outline-none"
+            />
+          </div>
+        </div>
+      </div>
+
+      {toast && (
+        <div className="fixed bottom-6 right-6 rounded-lg border border-border bg-popover px-4 py-2 text-sm text-popover-foreground shadow-lg">
+          {toast.message}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -19,7 +19,7 @@ const ThemeToggle = dynamic(
 
 const tools = [
   {
-    label: "Выделитель ШК/стоимости",
+    label: "Выделитель ШК/Стикера",
     href: "/tools/extractor",
   },
 ];

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+const ThemeToggle = dynamic(
+  () => import("@/components/ui/theme-toggle").then((mod) => mod.ThemeToggle),
+  { ssr: false }
+);
+
+const tools = [
+  {
+    label: "Выделитель ШК/стоимости",
+    href: "/tools/extractor",
+  },
+];
+
+export function AppHeader() {
+  const pathname = usePathname();
+
+  return (
+    <header className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-6 py-4">
+      <Link href="/" className="text-lg font-semibold text-foreground">
+        WMS Stats
+      </Link>
+      <div className="flex items-center gap-3">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button className="h-9 px-3 py-2 text-sm font-medium bg-transparent text-foreground hover:bg-muted">
+              Инструменты
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-[12rem]">
+            {tools.map((tool) => (
+              <DropdownMenuItem key={tool.href} asChild>
+                <Link
+                  href={tool.href}
+                  className={cn(
+                    "block w-full rounded-sm px-2 py-1.5 text-sm transition-colors",
+                    pathname?.startsWith(tool.href)
+                      ? "bg-accent text-accent-foreground"
+                      : "text-foreground"
+                  )}
+                >
+                  {tool.label}
+                </Link>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <ThemeToggle />
+      </div>
+    </header>
+  );
+}

--- a/src/lib/extractor.test.ts
+++ b/src/lib/extractor.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { parsePrices, parseSkus } from "./extractor";
+
+describe("parseSkus", () => {
+  const linearInput = `32963665262
+38399692351
+4 667,00 ₽
+30376042940
+38255891276
+955,00 ₽
+33226146669
+38877346304
+2 490,00 ₽`;
+
+  it("extracts SKUs from linear input", () => {
+    expect(parseSkus(linearInput)).toEqual([
+      "32963665262",
+      "30376042940",
+      "33226146669",
+    ]);
+  });
+
+  it("uses fallback extraction when other strategies fail", () => {
+    const fallbackInput = "12345678 99999999 77777777";
+    expect(parseSkus(fallbackInput)).toEqual(["12345678", "77777777"]);
+  });
+
+  it("supports tabular input", () => {
+    const tableInput = `ШК товара\tСтикер товара\tСтоимость товаров
+32963665262\tSticker A\t4 667,00 ₽
+30376042940\tSticker B\t955,00 ₽`;
+
+    expect(parseSkus(tableInput)).toEqual(["32963665262", "30376042940"]);
+  });
+
+  it("respects the unique flag", () => {
+    const duplicated = `${linearInput}\n30376042940`;
+    expect(parseSkus(duplicated, { unique: true })).toEqual([
+      "32963665262",
+      "30376042940",
+      "33226146669",
+    ]);
+    expect(parseSkus(duplicated, { unique: false })).toEqual([
+      "32963665262",
+      "30376042940",
+      "33226146669",
+      "30376042940",
+    ]);
+  });
+});
+
+describe("parsePrices", () => {
+  const linearInput = `32963665262
+38399692351
+4 667,00 ₽
+30376042940
+38255891276
+955,00 ₽
+33226146669
+38877346304
+2 490,00 ₽`;
+
+  it("extracts report-formatted prices from linear input", () => {
+    expect(parsePrices(linearInput, { format: "report" })).toEqual([
+      "4 667,00 ₽",
+      "955,00 ₽",
+      "2 490,00 ₽",
+    ]);
+  });
+
+  it("extracts excel-formatted prices from linear input", () => {
+    expect(parsePrices(linearInput, { format: "excel" })).toEqual([
+      "4667.00",
+      "955.00",
+      "2490.00",
+    ]);
+  });
+
+  it("supports tabular input", () => {
+    const tableInput = `ШК товара\tСтикер товара\tСтоимость товаров
+32963665262\tSticker A\t4 667,00 ₽
+30376042940\tSticker B\t955,00 ₽`;
+
+    expect(parsePrices(tableInput, { format: "report" })).toEqual([
+      "4 667,00 ₽",
+      "955,00 ₽",
+    ]);
+    expect(parsePrices(tableInput, { format: "excel" })).toEqual([
+      "4667.00",
+      "955.00",
+    ]);
+  });
+
+  it("respects the unique flag", () => {
+    const duplicated = `${linearInput}\n955,00 ₽`;
+    expect(parsePrices(duplicated, { format: "report", unique: true })).toEqual([
+      "4 667,00 ₽",
+      "955,00 ₽",
+      "2 490,00 ₽",
+    ]);
+    expect(parsePrices(duplicated, { format: "report", unique: false })).toEqual([
+      "4 667,00 ₽",
+      "955,00 ₽",
+      "2 490,00 ₽",
+      "955,00 ₽",
+    ]);
+  });
+});

--- a/src/lib/extractor.test.ts
+++ b/src/lib/extractor.test.ts
@@ -1,108 +1,71 @@
 import { describe, expect, it } from "vitest";
-import { parsePrices, parseSkus } from "./extractor";
+import { parseIds } from "./extractor";
 
-describe("parseSkus", () => {
-  const linearInput = `32963665262
-38399692351
+describe("parseIds", () => {
+  const linearInput = `32963665262 - это ШК
+38399692351 - это Стикер
 4 667,00 ₽
 30376042940
 38255891276
 955,00 ₽
 33226146669
 38877346304
-2 490,00 ₽`;
+2\u00A0490,00 ₽`;
 
   it("extracts SKUs from linear input", () => {
-    expect(parseSkus(linearInput)).toEqual([
+    expect(parseIds(linearInput, { mode: "sku" })).toEqual([
       "32963665262",
       "30376042940",
       "33226146669",
     ]);
   });
 
-  it("uses fallback extraction when other strategies fail", () => {
+  it("extracts stickers from linear input", () => {
+    expect(parseIds(linearInput, { mode: "sticker" })).toEqual([
+      "38399692351",
+      "38255891276",
+      "38877346304",
+    ]);
+  });
+
+  it("supports tabular input", () => {
+    const tableInput = `ШК товара\tСтикер товара\tСтоимость товаров
+32963665262\t38399692351\t4 667,00 ₽
+30376042940\t38255891276\t955,00 ₽`;
+
+    expect(parseIds(tableInput, { mode: "sku" })).toEqual([
+      "32963665262",
+      "30376042940",
+    ]);
+    expect(parseIds(tableInput, { mode: "sticker" })).toEqual([
+      "38399692351",
+      "38255891276",
+    ]);
+  });
+
+  it("uses fallback extraction when structured parsing fails", () => {
     const fallbackInput = "12345678 99999999 77777777";
-    expect(parseSkus(fallbackInput)).toEqual(["12345678", "77777777"]);
-  });
-
-  it("supports tabular input", () => {
-    const tableInput = `ШК товара\tСтикер товара\tСтоимость товаров
-32963665262\tSticker A\t4 667,00 ₽
-30376042940\tSticker B\t955,00 ₽`;
-
-    expect(parseSkus(tableInput)).toEqual(["32963665262", "30376042940"]);
-  });
-
-  it("respects the unique flag", () => {
-    const duplicated = `${linearInput}\n30376042940`;
-    expect(parseSkus(duplicated, { unique: true })).toEqual([
-      "32963665262",
-      "30376042940",
-      "33226146669",
+    expect(parseIds(fallbackInput, { mode: "sku" })).toEqual([
+      "12345678",
+      "77777777",
     ]);
-    expect(parseSkus(duplicated, { unique: false })).toEqual([
-      "32963665262",
-      "30376042940",
-      "33226146669",
-      "30376042940",
-    ]);
-  });
-});
-
-describe("parsePrices", () => {
-  const linearInput = `32963665262
-38399692351
-4 667,00 ₽
-30376042940
-38255891276
-955,00 ₽
-33226146669
-38877346304
-2 490,00 ₽`;
-
-  it("extracts report-formatted prices from linear input", () => {
-    expect(parsePrices(linearInput, { format: "report" })).toEqual([
-      "4 667,00 ₽",
-      "955,00 ₽",
-      "2 490,00 ₽",
-    ]);
-  });
-
-  it("extracts excel-formatted prices from linear input", () => {
-    expect(parsePrices(linearInput, { format: "excel" })).toEqual([
-      "4667.00",
-      "955.00",
-      "2490.00",
-    ]);
-  });
-
-  it("supports tabular input", () => {
-    const tableInput = `ШК товара\tСтикер товара\tСтоимость товаров
-32963665262\tSticker A\t4 667,00 ₽
-30376042940\tSticker B\t955,00 ₽`;
-
-    expect(parsePrices(tableInput, { format: "report" })).toEqual([
-      "4 667,00 ₽",
-      "955,00 ₽",
-    ]);
-    expect(parsePrices(tableInput, { format: "excel" })).toEqual([
-      "4667.00",
-      "955.00",
+    expect(parseIds(fallbackInput, { mode: "sticker" })).toEqual([
+      "99999999",
     ]);
   });
 
   it("respects the unique flag", () => {
-    const duplicated = `${linearInput}\n955,00 ₽`;
-    expect(parsePrices(duplicated, { format: "report", unique: true })).toEqual([
-      "4 667,00 ₽",
-      "955,00 ₽",
-      "2 490,00 ₽",
+    const duplicated = `${linearInput}\n30376042940\n38255891276`;
+    expect(parseIds(duplicated, { mode: "sku", unique: true })).toEqual([
+      "32963665262",
+      "30376042940",
+      "33226146669",
     ]);
-    expect(parsePrices(duplicated, { format: "report", unique: false })).toEqual([
-      "4 667,00 ₽",
-      "955,00 ₽",
-      "2 490,00 ₽",
-      "955,00 ₽",
+    expect(parseIds(duplicated, { mode: "sticker", unique: false })).toEqual([
+      "38399692351",
+      "38255891276",
+      "38877346304",
+      "38255891276",
     ]);
   });
 });

--- a/src/lib/extractor.ts
+++ b/src/lib/extractor.ts
@@ -1,25 +1,28 @@
 const HEADER_REGEX = /^(шк товара|стикер товара|стоимость товаров)$/i;
-const SKU_REGEX = /^\d{8,}$/;
-const PRICE_NUMBER_REGEX = /(\d[\s\d]*[.,]\d{2})/;
-const PRICE_WITH_CURRENCY_REGEX = /(\d[\s\d]*[.,]\d{2})\s*₽/i;
+const STRICT_NUMBER_REGEX = /^\d{8,}$/;
 const PRICE_LINE_REGEX = /\d[\s\d]*[.,]\d{2}\s*$/;
-const STICKER_REGEX = /стикер/i;
+
+type ExtractMode = "sku" | "sticker";
 
 interface NormalizeResult {
   text: string;
-  lines: string[];
   rawLines: string[];
+  lines: string[];
 }
 
-interface ParseSkuOptions {
+interface ParseIdOptions {
+  mode?: ExtractMode;
   unique?: boolean;
 }
 
-export type PriceFormat = "report" | "excel";
+interface Token {
+  type: "number" | "price";
+  value: string;
+}
 
-interface ParsePriceOptions {
-  unique?: boolean;
-  format?: PriceFormat;
+interface TokenizeResult {
+  tokens: Token[];
+  hasPrice: boolean;
 }
 
 function normalizeInput(raw: string): NormalizeResult {
@@ -32,7 +35,7 @@ function normalizeInput(raw: string): NormalizeResult {
     .map((line) => line.trim())
     .filter((line) => line.length > 0 && !HEADER_REGEX.test(line));
 
-  return { text, lines, rawLines };
+  return { text, rawLines, lines };
 }
 
 function ensureUnique(values: string[], unique?: boolean): string[] {
@@ -52,196 +55,117 @@ function ensureUnique(values: string[], unique?: boolean): string[] {
   return result;
 }
 
-function formatReportValue(value: number): string {
-  const formatted = new Intl.NumberFormat("ru-RU", {
-    style: "currency",
-    currency: "RUB",
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(value);
-
-  return formatted.replace(/\u00A0/g, " ");
+function isPriceLine(line: string): boolean {
+  const normalized = line.replace(/\s+/g, " ");
+  return normalized.includes("₽") || PRICE_LINE_REGEX.test(normalized);
 }
 
-function formatExcelValue(value: number): string {
-  return value.toFixed(2);
-}
-
-function extractNumericValue(candidate: string): number | null {
-  const normalized = candidate.replace(/[\u00A0\u202F]/g, " ").replace(/\s+/g, " ").trim();
-  const withCurrency = normalized.match(PRICE_WITH_CURRENCY_REGEX);
-
-  if (withCurrency) {
-    return parseNumeric(withCurrency[1]);
-  }
-
-  const plainMatch = normalized.match(PRICE_NUMBER_REGEX);
-  if (plainMatch) {
-    return parseNumeric(plainMatch[1]);
-  }
-
-  return null;
-}
-
-function parseNumeric(value: string): number | null {
-  const digits = value.replace(/\s+/g, "").replace(/,/g, ".");
-  const parsed = Number.parseFloat(digits);
-
-  if (Number.isNaN(parsed)) {
-    return null;
-  }
-
-  return parsed;
-}
-
-export function parseSkus(raw: string, options: ParseSkuOptions = {}): string[] {
-  const { unique } = options;
-  const normalized = normalizeInput(raw);
+function extractFromTable(
+  normalized: NormalizeResult,
+  columnIndex: number
+): string[] {
   const results: string[] = [];
 
-  const hasTabs = normalized.text.includes("\t");
+  for (const rawLine of normalized.rawLines) {
+    if (!rawLine.includes("\t")) continue;
 
-  if (hasTabs) {
-    for (const rawLine of normalized.rawLines) {
-      if (!rawLine.includes("\t")) continue;
-      const [firstColumn] = rawLine.split("\t");
-      const value = firstColumn?.trim();
-      if (value && SKU_REGEX.test(value)) {
-        results.push(value);
-      }
-    }
+    const columns = rawLine.split("\t");
+    if (columns.length <= columnIndex) continue;
 
-    if (results.length > 0) {
-      return ensureUnique(results, unique);
+    const candidate = columns[columnIndex]?.trim();
+    if (candidate && STRICT_NUMBER_REGEX.test(candidate)) {
+      results.push(candidate);
     }
   }
 
-  let firstNumberCaptured = false;
-  let previousWasPrice = false;
-
-  for (const line of normalized.lines) {
-    const isPriceLine = line.includes("₽") || PRICE_LINE_REGEX.test(line);
-
-    if (isPriceLine) {
-      previousWasPrice = true;
-      continue;
-    }
-
-    if (SKU_REGEX.test(line)) {
-      if (!firstNumberCaptured) {
-        results.push(line);
-        firstNumberCaptured = true;
-      } else if (previousWasPrice) {
-        results.push(line);
-      }
-
-      previousWasPrice = false;
-      continue;
-    }
-
-    previousWasPrice = false;
-  }
-
-  if (results.length > 0) {
-    return ensureUnique(results, unique);
-  }
-
-  const fallbackMatches = Array.from(normalized.text.matchAll(/\d{8,}/g)).map((match) => match[0]);
-  const fallbackResults: string[] = [];
-
-  for (let index = 0; index < fallbackMatches.length; index += 2) {
-    const value = fallbackMatches[index];
-    if (value) {
-      fallbackResults.push(value);
-    }
-  }
-
-  return ensureUnique(fallbackResults, unique);
+  return results;
 }
 
-export function parsePrices(
-  raw: string,
-  options: ParsePriceOptions = {}
-): string[] {
-  const { unique, format = "report" } = options;
+function tokenize(lines: string[]): TokenizeResult {
+  const tokens: Token[] = [];
+  let hasPrice = false;
+
+  for (const line of lines) {
+    if (line.includes("\t")) continue;
+
+    if (isPriceLine(line)) {
+      tokens.push({ type: "price", value: line });
+      hasPrice = true;
+      continue;
+    }
+
+    const matches = line.match(/\d{8,}/g);
+    if (!matches) continue;
+
+    for (const match of matches) {
+      if (STRICT_NUMBER_REGEX.test(match)) {
+        tokens.push({ type: "number", value: match });
+      }
+    }
+  }
+
+  return { tokens, hasPrice };
+}
+
+function extractFromTokens(tokens: Token[]): { sku: string; sticker: string }[] {
+  const pairs: { sku: string; sticker: string }[] = [];
+
+  for (let index = 0; index < tokens.length; ) {
+    const first = tokens[index];
+    const second = tokens[index + 1];
+
+    if (first?.type === "number" && second?.type === "number") {
+      const third = tokens[index + 2];
+      pairs.push({ sku: first.value, sticker: second.value });
+
+      if (third?.type === "price") {
+        index += 3;
+      } else {
+        index += 2;
+      }
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return pairs;
+}
+
+export function parseIds(raw: string, options: ParseIdOptions = {}): string[] {
+  const { mode = "sku", unique = true } = options;
   const normalized = normalizeInput(raw);
-  const values: number[] = [];
   const hasTabs = normalized.text.includes("\t");
 
   if (hasTabs) {
-    for (const rawLine of normalized.rawLines) {
-      if (!rawLine.includes("\t")) continue;
-      const columns = rawLine.split("\t");
-      if (columns.length < 3) continue;
-      const candidate = columns[2]?.trim();
-      if (!candidate) continue;
-      const numeric = extractNumericValue(candidate);
-      if (numeric !== null) {
-        values.push(numeric);
-      }
-    }
-
-    if (values.length > 0) {
-      return formatPrices(values, { unique, format });
+    const columnIndex = mode === "sku" ? 0 : 1;
+    const tabular = extractFromTable(normalized, columnIndex);
+    if (tabular.length > 0) {
+      return ensureUnique(tabular, unique);
     }
   }
 
-  let lastLineType: "none" | "sku" | "sticker" | "price" = "none";
+  const { tokens, hasPrice } = tokenize(normalized.lines);
+  const pairs = extractFromTokens(tokens);
 
-  for (const line of normalized.lines) {
-    if (SKU_REGEX.test(line)) {
-      lastLineType = "sku";
-      continue;
-    }
-
-    if (STICKER_REGEX.test(line)) {
-      lastLineType = "sticker";
-      continue;
-    }
-
-    const normalizedLine = line.replace(/\s+/g, " ");
-    const withCurrency = normalizedLine.match(PRICE_WITH_CURRENCY_REGEX);
-    if (withCurrency) {
-      const numeric = parseNumeric(withCurrency[1]);
-      if (numeric !== null) {
-        values.push(numeric);
-        lastLineType = "price";
-        continue;
-      }
-    }
-
-    const plainMatch = normalizedLine.match(PRICE_NUMBER_REGEX);
-    if (plainMatch && (lastLineType === "sticker" || lastLineType === "sku")) {
-      const numeric = parseNumeric(plainMatch[1]);
-      if (numeric !== null) {
-        values.push(numeric);
-        lastLineType = "price";
-        continue;
-      }
-    }
-
-    if (plainMatch && normalizedLine.toLowerCase().includes("стоим")) {
-      const numeric = parseNumeric(plainMatch[1]);
-      if (numeric !== null) {
-        values.push(numeric);
-        lastLineType = "price";
-        continue;
-      }
-    }
-
-    lastLineType = "none";
+  if (pairs.length > 0 && hasPrice) {
+    const extracted = pairs.map((pair) => (mode === "sku" ? pair.sku : pair.sticker));
+    return ensureUnique(extracted, unique);
   }
 
-  return formatPrices(values, { unique, format });
-}
-
-function formatPrices(
-  values: number[],
-  options: Required<Pick<ParsePriceOptions, "format">> & Pick<ParsePriceOptions, "unique">
-): string[] {
-  const formatted = values.map((value) =>
-    options.format === "report" ? formatReportValue(value) : formatExcelValue(value)
+  const fallbackMatches = Array.from(normalized.text.matchAll(/\d{8,}/g)).map(
+    (match) => match[0]
   );
 
-  return ensureUnique(formatted, options.unique);
+  const fallback: string[] = [];
+  const startIndex = mode === "sku" ? 0 : 1;
+
+  for (let index = startIndex; index < fallbackMatches.length; index += 2) {
+    const value = fallbackMatches[index];
+    if (value && STRICT_NUMBER_REGEX.test(value)) {
+      fallback.push(value);
+    }
+  }
+
+  return ensureUnique(fallback, unique);
 }

--- a/src/lib/extractor.ts
+++ b/src/lib/extractor.ts
@@ -1,0 +1,247 @@
+const HEADER_REGEX = /^(шк товара|стикер товара|стоимость товаров)$/i;
+const SKU_REGEX = /^\d{8,}$/;
+const PRICE_NUMBER_REGEX = /(\d[\s\d]*[.,]\d{2})/;
+const PRICE_WITH_CURRENCY_REGEX = /(\d[\s\d]*[.,]\d{2})\s*₽/i;
+const PRICE_LINE_REGEX = /\d[\s\d]*[.,]\d{2}\s*$/;
+const STICKER_REGEX = /стикер/i;
+
+interface NormalizeResult {
+  text: string;
+  lines: string[];
+  rawLines: string[];
+}
+
+interface ParseSkuOptions {
+  unique?: boolean;
+}
+
+export type PriceFormat = "report" | "excel";
+
+interface ParsePriceOptions {
+  unique?: boolean;
+  format?: PriceFormat;
+}
+
+function normalizeInput(raw: string): NormalizeResult {
+  const text = raw
+    .replace(/\r\n?|\r/g, "\n")
+    .replace(/[\u00A0\u202F]/g, " ");
+
+  const rawLines = text.split("\n");
+  const lines = rawLines
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !HEADER_REGEX.test(line));
+
+  return { text, lines, rawLines };
+}
+
+function ensureUnique(values: string[], unique?: boolean): string[] {
+  if (!unique) {
+    return values;
+  }
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+  }
+
+  return result;
+}
+
+function formatReportValue(value: number): string {
+  const formatted = new Intl.NumberFormat("ru-RU", {
+    style: "currency",
+    currency: "RUB",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+
+  return formatted.replace(/\u00A0/g, " ");
+}
+
+function formatExcelValue(value: number): string {
+  return value.toFixed(2);
+}
+
+function extractNumericValue(candidate: string): number | null {
+  const normalized = candidate.replace(/[\u00A0\u202F]/g, " ").replace(/\s+/g, " ").trim();
+  const withCurrency = normalized.match(PRICE_WITH_CURRENCY_REGEX);
+
+  if (withCurrency) {
+    return parseNumeric(withCurrency[1]);
+  }
+
+  const plainMatch = normalized.match(PRICE_NUMBER_REGEX);
+  if (plainMatch) {
+    return parseNumeric(plainMatch[1]);
+  }
+
+  return null;
+}
+
+function parseNumeric(value: string): number | null {
+  const digits = value.replace(/\s+/g, "").replace(/,/g, ".");
+  const parsed = Number.parseFloat(digits);
+
+  if (Number.isNaN(parsed)) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function parseSkus(raw: string, options: ParseSkuOptions = {}): string[] {
+  const { unique } = options;
+  const normalized = normalizeInput(raw);
+  const results: string[] = [];
+
+  const hasTabs = normalized.text.includes("\t");
+
+  if (hasTabs) {
+    for (const rawLine of normalized.rawLines) {
+      if (!rawLine.includes("\t")) continue;
+      const [firstColumn] = rawLine.split("\t");
+      const value = firstColumn?.trim();
+      if (value && SKU_REGEX.test(value)) {
+        results.push(value);
+      }
+    }
+
+    if (results.length > 0) {
+      return ensureUnique(results, unique);
+    }
+  }
+
+  let firstNumberCaptured = false;
+  let previousWasPrice = false;
+
+  for (const line of normalized.lines) {
+    const isPriceLine = line.includes("₽") || PRICE_LINE_REGEX.test(line);
+
+    if (isPriceLine) {
+      previousWasPrice = true;
+      continue;
+    }
+
+    if (SKU_REGEX.test(line)) {
+      if (!firstNumberCaptured) {
+        results.push(line);
+        firstNumberCaptured = true;
+      } else if (previousWasPrice) {
+        results.push(line);
+      }
+
+      previousWasPrice = false;
+      continue;
+    }
+
+    previousWasPrice = false;
+  }
+
+  if (results.length > 0) {
+    return ensureUnique(results, unique);
+  }
+
+  const fallbackMatches = Array.from(normalized.text.matchAll(/\d{8,}/g)).map((match) => match[0]);
+  const fallbackResults: string[] = [];
+
+  for (let index = 0; index < fallbackMatches.length; index += 2) {
+    const value = fallbackMatches[index];
+    if (value) {
+      fallbackResults.push(value);
+    }
+  }
+
+  return ensureUnique(fallbackResults, unique);
+}
+
+export function parsePrices(
+  raw: string,
+  options: ParsePriceOptions = {}
+): string[] {
+  const { unique, format = "report" } = options;
+  const normalized = normalizeInput(raw);
+  const values: number[] = [];
+  const hasTabs = normalized.text.includes("\t");
+
+  if (hasTabs) {
+    for (const rawLine of normalized.rawLines) {
+      if (!rawLine.includes("\t")) continue;
+      const columns = rawLine.split("\t");
+      if (columns.length < 3) continue;
+      const candidate = columns[2]?.trim();
+      if (!candidate) continue;
+      const numeric = extractNumericValue(candidate);
+      if (numeric !== null) {
+        values.push(numeric);
+      }
+    }
+
+    if (values.length > 0) {
+      return formatPrices(values, { unique, format });
+    }
+  }
+
+  let lastLineType: "none" | "sku" | "sticker" | "price" = "none";
+
+  for (const line of normalized.lines) {
+    if (SKU_REGEX.test(line)) {
+      lastLineType = "sku";
+      continue;
+    }
+
+    if (STICKER_REGEX.test(line)) {
+      lastLineType = "sticker";
+      continue;
+    }
+
+    const normalizedLine = line.replace(/\s+/g, " ");
+    const withCurrency = normalizedLine.match(PRICE_WITH_CURRENCY_REGEX);
+    if (withCurrency) {
+      const numeric = parseNumeric(withCurrency[1]);
+      if (numeric !== null) {
+        values.push(numeric);
+        lastLineType = "price";
+        continue;
+      }
+    }
+
+    const plainMatch = normalizedLine.match(PRICE_NUMBER_REGEX);
+    if (plainMatch && (lastLineType === "sticker" || lastLineType === "sku")) {
+      const numeric = parseNumeric(plainMatch[1]);
+      if (numeric !== null) {
+        values.push(numeric);
+        lastLineType = "price";
+        continue;
+      }
+    }
+
+    if (plainMatch && normalizedLine.toLowerCase().includes("стоим")) {
+      const numeric = parseNumeric(plainMatch[1]);
+      if (numeric !== null) {
+        values.push(numeric);
+        lastLineType = "price";
+        continue;
+      }
+    }
+
+    lastLineType = "none";
+  }
+
+  return formatPrices(values, { unique, format });
+}
+
+function formatPrices(
+  values: number[],
+  options: Required<Pick<ParsePriceOptions, "format">> & Pick<ParsePriceOptions, "unique">
+): string[] {
+  const formatted = values.map((value) =>
+    options.format === "report" ? formatReportValue(value) : formatExcelValue(value)
+  );
+
+  return ensureUnique(formatted, options.unique);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: false,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a reusable app header with navigation entry for the SKU/price extractor
- implement the client-side extractor tool page with keyboard shortcuts, formatting options, and downloads
- create SKU and price parsing utilities with vitest coverage and configure Vitest test runner

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d8084db568832ba3a266ec4399ac64