### PR TITLE
Enhance background themes for night sky and morning mist

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,20 +5,20 @@
 @layer base {
   :root {
     /* light theme */
-    --background: 42 38% 96%; /* #F8F1E8 */
-    --foreground: 210 33% 14%; /* #1F2A36 */
-    --card: 210 26% 94%; /* #E6ECF2 */
-    --card-foreground: 210 33% 14%;
+    --background: 38 46% 97%; /* morning mist base */
+    --foreground: 214 26% 16%;
+    --card: 210 28% 94%;
+    --card-foreground: 214 26% 16%;
     --popover: 0 0% 100%;
-    --popover-foreground: 210 33% 14%;
-    --primary: 207 45% 22%;
+    --popover-foreground: 214 26% 16%;
+    --primary: 214 42% 24%;
     --primary-foreground: 0 0% 98%;
-    --secondary: 42 32% 92%;
-    --secondary-foreground: 210 33% 14%;
-    --muted: 210 20% 90%;
-    --muted-foreground: 215 16% 38%;
-    --accent: 195 26% 88%;
-    --accent-foreground: 210 33% 14%;
+    --secondary: 42 30% 92%;
+    --secondary-foreground: 214 26% 16%;
+    --muted: 210 22% 90%;
+    --muted-foreground: 215 16% 36%;
+    --accent: 218 32% 88%;
+    --accent-foreground: 214 26% 16%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
     --border: 210 18% 82%;
@@ -27,46 +27,46 @@
     --radius: 0.5rem;
 
     /* liquid glass tokens */
-    --glass-bg: hsl(var(--card) / 0.75);
-    --glass-border: hsl(var(--foreground) / 0.08);
-    --glass-shadow: 0 18px 40px hsl(var(--foreground) / 0.08);
+    --glass-bg: hsl(var(--card) / 0.82);
+    --glass-border: hsl(var(--foreground) / 0.12);
+    --glass-shadow: 0 18px 40px hsl(var(--foreground) / 0.1);
     --glass-blur: 12px;
     --glass-ring: hsl(var(--ring) / 0.35);
   }
 
   .dark {
     /* dark theme */
-    --background: 205.7 45.2% 12.2%; /* #11212D */
-    --foreground: 165 4.1% 80.8%; /* #CCD0CF */
-    --card: 207.9 34.1% 16.1%; /* #1B2A37 */
-    --card-foreground: 165 4.1% 80.8%;
-    --popover: 240 10% 3.9%;
+    --background: 222 42% 7%; /* deep night base */
+    --foreground: 210 18% 88%;
+    --card: 220 32% 12%;
+    --card-foreground: 210 18% 88%;
+    --popover: 222 36% 8%;
     --popover-foreground: 0 0% 98%;
     --primary: 0 0% 98%;
     --primary-foreground: 240 5.9% 10%;
-    --secondary: 240 3.7% 15.9%;
+    --secondary: 224 28% 14%;
     --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
+    --muted: 224 24% 16%;
+    --muted-foreground: 220 10% 74%;
+    --accent: 224 24% 18%;
     --accent-foreground: 0 0% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 240 4.9% 83.9%;
+    --border: 224 24% 18%;
+    --input: 224 24% 18%;
+    --ring: 240 10% 76%;
 
     /* liquid glass tokens */
     --glass-bg: linear-gradient(
-      145deg,
-      hsl(210 35% 16% / 0.8),
-      hsl(207 36% 14% / 0.82),
-      hsl(204 34% 12% / 0.92)
+      155deg,
+      hsl(220 34% 16% / 0.88),
+      hsl(223 36% 13% / 0.82),
+      hsl(226 38% 12% / 0.78)
     );
-    --glass-border: hsl(var(--foreground) / 0.18);
-    --glass-shadow: 0 20px 50px hsl(214 44% 10% / 0.55);
+    --glass-border: hsl(var(--foreground) / 0.22);
+    --glass-shadow: 0 24px 60px hsl(220 45% 7% / 0.65);
     --glass-blur: 16px;
-    --glass-ring: hsl(var(--ring) / 0.45);
+    --glass-ring: hsl(var(--ring) / 0.48);
   }
 }
 
@@ -79,18 +79,38 @@
     font-feature-settings: "rlig" 1, "calt" 1;
     background-color: hsl(var(--background));
     background-image:
-      radial-gradient(110% 80% at 12% 14%, hsl(var(--accent) / 0.25), transparent 55%),
-      radial-gradient(120% 90% at 88% 6%, hsl(var(--primary) / 0.16), transparent 58%),
-      linear-gradient(180deg, hsl(var(--background)) 0%, hsl(var(--background) / 0.85) 35%, hsl(var(--card) / 0.65) 100%);
+      radial-gradient(80% 40% at 50% 96%, hsl(270 50% 70% / 0.16), transparent 70%),
+      radial-gradient(90% 55% at 14% 10%, hsl(var(--accent) / 0.18), transparent 55%),
+      radial-gradient(110% 70% at 88% 8%, hsl(var(--primary) / 0.12), transparent 60%),
+      linear-gradient(180deg, hsl(var(--background)) 0%, hsl(var(--background) / 0.9) 36%, hsl(var(--card) / 0.72) 100%);
     background-attachment: fixed;
   }
 
   .dark body {
     background-image:
-      radial-gradient(120% 110% at 20% 10%, hsl(209 60% 32% / 0.2), transparent 60%),
-      radial-gradient(140% 120% at 78% 12%, hsl(217 65% 18% / 0.28), transparent 65%),
-      radial-gradient(140% 130% at 50% 95%, hsl(215 50% 12% / 0.6), transparent 75%),
-      linear-gradient(180deg, #0c121b 0%, #0f1a28 30%, #0b1320 100%);
+      radial-gradient(1px 1px at 20% 30%, rgba(255, 255, 255, 0.8), transparent),
+      radial-gradient(1px 1px at 78% 44%, rgba(210, 230, 255, 0.65), transparent),
+      radial-gradient(1px 1px at 52% 76%, rgba(255, 255, 255, 0.7), transparent),
+      radial-gradient(60% 42% at 50% 106%, hsl(270 67% 54% / 0.32), transparent 72%),
+      radial-gradient(70% 46% at 64% 102%, hsl(255 64% 48% / 0.24), transparent 75%),
+      radial-gradient(140% 120% at 50% 50%, transparent 62%, rgba(2, 4, 12, 0.7)),
+      linear-gradient(180deg, #050812 0%, #080c18 32%, #040713 100%);
+    background-size:
+      260px 260px,
+      340px 340px,
+      420px 420px,
+      100% 100%,
+      100% 100%,
+      100% 100%,
+      100% 100%;
+    background-repeat:
+      repeat,
+      repeat,
+      repeat,
+      no-repeat,
+      no-repeat,
+      no-repeat,
+      no-repeat;
     background-attachment: fixed;
   }
 }


### PR DESCRIPTION
## Summary
- refresh light theme tokens for a soft “morning mist” base with gentle gradient accents
- craft a dark “space night sky” background with CSS star field, nebula glows, and vignette
- adjust liquid glass styling for better contrast across both themes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695543a78f4c832b825995e0430a5f5d)