### PR TITLE
Fix client crash on status search; add JSON guards and ErrorBoundary

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 
 import { ThemeProvider } from "@/components/theme-provider";
+import ErrorBoundary from "@/components/ErrorBoundary";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -31,9 +32,11 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <div className="min-h-screen w-full bg-background transition-colors duration-500">
-            {children}
-          </div>
+          <ErrorBoundary>
+            <div className="min-h-screen w-full bg-background transition-colors duration-500">
+              {children}
+            </div>
+          </ErrorBoundary>
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React from "react";
+
+type Props = {
+  children: React.ReactNode;
+};
+
+type State = {
+  hasError: boolean;
+  errorMessage: string | null;
+};
+
+class ErrorBoundary extends React.Component<Props, State> {
+  state: State = {
+    hasError: false,
+    errorMessage: null,
+  };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, errorMessage: error.message };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error("UI crash caught by ErrorBoundary", error, info);
+  }
+
+  handleReload = () => {
+    if (typeof window !== "undefined") {
+      window.location.reload();
+    }
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col items-center justify-center gap-4 px-6 text-center">
+          <h1 className="text-2xl font-semibold">Что-то пошло не так</h1>
+          <p className="text-sm text-muted-foreground">
+            Попробуйте обновить страницу. Если проблема повторяется, проверьте ввод или сеть.
+          </p>
+          {this.state.errorMessage && (
+            <p className="text-xs text-muted-foreground">
+              Детали: {this.state.errorMessage}
+            </p>
+          )}
+          <button
+            type="button"
+            className="rounded-full border border-border px-4 py-2 text-sm transition hover:border-foreground/60"
+            onClick={this.handleReload}
+          >
+            Обновить страницу
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/StatusCard.tsx
+++ b/src/components/StatusCard.tsx
@@ -10,11 +10,20 @@ interface Props {
   query: string;
 }
 
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function highlight(text: string, query: string) {
-  if (!query) return text;
-  const regex = new RegExp(`(${query})`, "gi");
-  return text.split(regex).map((part, i) =>
-    regex.test(part) ? (
+  const safeText = text ?? "";
+  const trimmedQuery = query.trim();
+  if (!trimmedQuery) return safeText;
+  const escapedQuery = escapeRegExp(trimmedQuery);
+  const splitRegex = new RegExp(`(${escapedQuery})`, "gi");
+  const lowerQuery = trimmedQuery.toLowerCase();
+
+  return safeText.split(splitRegex).map((part, i) =>
+    part.toLowerCase() === lowerQuery ? (
       <span key={i} className="bg-foreground/20">
         {part}
       </span>

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -8,11 +8,17 @@ export function useSearch() {
   const results = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return [];
-    return statuses.filter((s) =>
-      s.code.toLowerCase().includes(q) ||
-      s.description.toLowerCase().includes(q) ||
-      (s.action && s.action.toLowerCase().includes(q))
-    );
+    return statuses.filter((status) => {
+      if (!status) return false;
+      const code = status.code?.toLowerCase?.() ?? "";
+      const description = status.description?.toLowerCase?.() ?? "";
+      const action = status.action?.toLowerCase?.() ?? "";
+      return (
+        code.includes(q) ||
+        description.includes(q) ||
+        (action && action.includes(q))
+      );
+    });
   }, [query, statuses]);
 
   const clear = () => setQuery("");

--- a/src/hooks/useStatuses.ts
+++ b/src/hooks/useStatuses.ts
@@ -12,17 +12,73 @@ export function useStatuses() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch("/api/statuses")
-      .then((res) => {
-        if (!res.ok) throw new Error("Ошибка сети");
-        return res.json();
-      })
-      .then((data) => setStatuses(data.statuses)) // ✅ важно!
-      .catch((err) => {
+    let isActive = true;
+
+    const loadStatuses = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const res = await fetch("/api/statuses", {
+          headers: { Accept: "application/json" },
+        });
+
+        if (!res.ok) {
+          throw new Error(`Ошибка сети: ${res.status}`);
+        }
+
+        const rawText = await res.text();
+        let data: unknown;
+
+        try {
+          data = rawText ? JSON.parse(rawText) : {};
+        } catch (parseError) {
+          throw new Error("Некорректный JSON от сервера");
+        }
+
+        const rawStatuses = Array.isArray((data as { statuses?: unknown }).statuses)
+          ? (data as { statuses: unknown[] }).statuses
+          : [];
+
+        const normalized = rawStatuses
+          .map((item) => {
+            if (!item || typeof item !== "object") return null;
+            const record = item as Record<string, unknown>;
+            const code = typeof record.code === "string" ? record.code : String(record.code ?? "");
+            const description =
+              typeof record.description === "string"
+                ? record.description
+                : String(record.description ?? "");
+            const action =
+              record.action == null
+                ? ""
+                : typeof record.action === "string"
+                  ? record.action
+                  : String(record.action);
+            return { code, description, action };
+          })
+          .filter((value): value is Status => Boolean(value));
+
+        if (isActive) {
+          setStatuses(normalized);
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Неизвестная ошибка";
         console.error("Ошибка при загрузке статусов", err);
-        setError(err.message);
-      })
-      .finally(() => setLoading(false));
+        if (isActive) {
+          setError(message);
+        }
+      } finally {
+        if (isActive) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadStatuses();
+
+    return () => {
+      isActive = false;
+    };
   }, []);
 
   return { statuses, loading, error };


### PR DESCRIPTION
### Motivation
- Root cause: unescaped user input was interpolated into a `RegExp` in `src/components/StatusCard.tsx`, which throws on special characters and caused a client-side crash. 
- Prevent crashes from malformed/empty API responses, network errors, or unexpected data shape during search and rendering.
- Add a lightweight UI-level safeguard so a single client exception does not become a white screen for the whole app.

### Description
- Escape search query and make `highlight` resilient to `null`/`undefined` text to avoid `Invalid regular expression` errors by changing `src/components/StatusCard.tsx` (adds `escapeRegExp` and safer splitting/comparison). 
- Harden the fetch flow in `src/hooks/useStatuses.ts` to use `async/await`, explicit `res.text()` + `JSON.parse` with parse error handling, normalize records to `{ code, description, action }`, and avoid setting state after unmount. 
- Add runtime guards in `src/hooks/useSearch.ts` to tolerate missing fields and avoid calling `.toLowerCase()` on `undefined`. 
- Add a client `ErrorBoundary` component (`src/components/ErrorBoundary.tsx`) and wrap the app root in `src/app/layout.tsx` so UI crashes are caught and a fallback UI is shown. 
- Files changed: `src/components/StatusCard.tsx`, `src/hooks/useStatuses.ts`, `src/hooks/useSearch.ts`, `src/components/ErrorBoundary.tsx`, `src/app/layout.tsx`.

### Testing
- Automated tests: none executed for this patch (no CI/test run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697da2710540832b9ac6e99cd7ca19b8)