### PR TITLE
Add Vercel Analytics to root layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.7",
         "@radix-ui/react-slot": "^1.0.2",
+        "@vercel/analytics": "^1.6.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "dotenv": "^16.5.0",
@@ -3136,6 +3137,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.7",
     "@radix-ui/react-slot": "^1.0.2",
+    "@vercel/analytics": "^1.6.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "dotenv": "^16.5.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Analytics } from "@vercel/analytics/react";
 import { Inter } from "next/font/google";
 import "./globals.css";
 
@@ -38,6 +39,7 @@ export default function RootLayout({
             </div>
           </ErrorBoundary>
         </ThemeProvider>
+        <Analytics />
       </body>
     </html>
   );


### PR DESCRIPTION
### Motivation
- Enable Vercel Web Analytics to record visitors and pageviews by adding the official `@vercel/analytics` integration exactly once at the app root without changing existing logic, styles, or adding a client directive.

### Description
- Add `@vercel/analytics` to `package.json` and the lockfile and install the package with `npm install`.
- Import `Analytics` from `@vercel/analytics/react` and render a single `<Analytics />` in `src/app/layout.tsx` (root layout) after the `</ThemeProvider>` while leaving the layout code, styles, and structure otherwise unchanged and without adding `use client`.

### Testing
- No automated tests were run; dependency installation completed locally via `npm install` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697da611782c832bb6d89701d00cfeac)